### PR TITLE
Update onebox assistant for current Discourse core

### DIFF
--- a/lib/discourse_onebox_assistant/proxy_service.rb
+++ b/lib/discourse_onebox_assistant/proxy_service.rb
@@ -7,7 +7,16 @@ module ::DiscourseOneboxAssistant
   class ProxyService
     def page_source(url)
       response = HTTParty.get(request_url(url), headers: request_headers)
-      response[
+
+      unless response.success? && response.parsed_response.is_a?(Hash)
+        Rails.logger.warn(
+          "ONEBOX ASSIST: unexpected response for #{url} " \
+            "(status=#{response.code}, body=#{response.body.to_s.byteslice(0, 300)})"
+        )
+        return nil
+      end
+
+      response.parsed_response[
         SiteSetting.onebox_assistant_api_page_source_field
       ].tap do |page_source|
         if page_source.nil?

--- a/lib/discourse_onebox_assistant/proxy_service.rb
+++ b/lib/discourse_onebox_assistant/proxy_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require "httparty"
 
 module ::DiscourseOneboxAssistant
@@ -23,7 +24,7 @@ module ::DiscourseOneboxAssistant
       [
         SiteSetting.onebox_assistant_api_base_address,
         SiteSetting.onebox_assistant_api_base_query,
-        url,
+        CGI.escape(url.to_s),
         SiteSetting.onebox_assistant_api_options
       ].join
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-onebox-assistant
 # about: provides alternative path for grabbing one-boxes when initial crawl fails
-# version: 3.1.0
+# version: 3.1.1
 # authors: merefield
 # url: https://github.com/merefield/discourse-onebox-assistant
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -158,6 +158,13 @@ RSpec.describe DiscourseOneboxAssistant::ProxyService do
   describe "#page_source" do
     it "escapes the target URL before calling the proxy service" do
       target_url = "https://www.example.com/path?a=1&b=two words#fragment"
+      response =
+        stub(
+          success?: true,
+          parsed_response: { "source" => "<p>proxy</p>" },
+          code: 200,
+          body: '{"source":"<p>proxy</p>"}'
+        )
 
       HTTParty
         .expects(:get)
@@ -165,9 +172,40 @@ RSpec.describe DiscourseOneboxAssistant::ProxyService do
           "https://proxy.example.com?url=https%3A%2F%2Fwww.example.com%2Fpath%3Fa%3D1%26b%3Dtwo+words%23fragment&render_js=false",
           headers: { "x-api-key" => "secret" }
         )
-        .returns({ "source" => "<p>proxy</p>" })
+        .returns(response)
 
       expect(described_class.new.page_source(target_url)).to eq("<p>proxy</p>")
+    end
+
+    it "returns nil when the proxy response is unsuccessful" do
+      response =
+        stub(success?: false, parsed_response: nil, code: 500, body: "server error")
+
+      HTTParty.expects(:get).returns(response)
+      Rails.logger.expects(:warn).with(
+        "ONEBOX ASSIST: unexpected response for https://example.com " \
+          "(status=500, body=server error)"
+      )
+
+      expect(described_class.new.page_source("https://example.com")).to eq(nil)
+    end
+
+    it "returns nil when the proxy response is not a hash" do
+      response =
+        stub(
+          success?: true,
+          parsed_response: "<html>not json</html>",
+          code: 200,
+          body: "<html>not json</html>"
+        )
+
+      HTTParty.expects(:get).returns(response)
+      Rails.logger.expects(:warn).with(
+        "ONEBOX ASSIST: unexpected response for https://example.com " \
+          "(status=200, body=<html>not json</html>)"
+      )
+
+      expect(described_class.new.page_source("https://example.com")).to eq(nil)
     end
   end
 end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -145,3 +145,29 @@ RSpec.describe Onebox::Helpers do
     end
   end
 end
+
+RSpec.describe DiscourseOneboxAssistant::ProxyService do
+  before do
+    SiteSetting.onebox_assistant_api_base_address = "https://proxy.example.com"
+    SiteSetting.onebox_assistant_api_base_query = "?url="
+    SiteSetting.onebox_assistant_api_options = "&render_js=false"
+    SiteSetting.onebox_assistant_api_page_source_field = "source"
+    SiteSetting.onebox_assistant_api_key = "secret"
+  end
+
+  describe "#page_source" do
+    it "escapes the target URL before calling the proxy service" do
+      target_url = "https://www.example.com/path?a=1&b=two words#fragment"
+
+      HTTParty
+        .expects(:get)
+        .with(
+          "https://proxy.example.com?url=https%3A%2F%2Fwww.example.com%2Fpath%3Fa%3D1%26b%3Dtwo+words%23fragment&render_js=false",
+          headers: { "x-api-key" => "secret" }
+        )
+        .returns({ "source" => "<p>proxy</p>" })
+
+      expect(described_class.new.page_source(target_url)).to eq("<p>proxy</p>")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- align the onebox assistant overrides with current Discourse core behavior
- refactor the plugin to use helper methods and a namespaced proxy service
- add regression coverage for blocked-page handling and canonical proxy follow-up
- add CI, standalone plugin Gemfile support, RuboCop config, and a lockfile
- harden proxy requests by escaping target URLs and validating proxy responses

## Testing
- bin/rspec plugins/discourse-onebox-assistant/spec/plugin_spec.rb
- bundle exec rubocop -a Gemfile discourse/lib/onebox/helpers_edits.rb discourse/lib/oneboxer_edits.rb lib/
  discourse_onebox_assistant/proxy_service.rb plugin.rb spec/plugin_spec.rb
- bin/lint plugins/discourse-onebox-assistant/plugin.rb